### PR TITLE
Add ms plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,28 @@ Will load as:
 }
 ```
 
+### config.ms
+
+``` js
+config.use(config.ms);
+```
+
+Replaces ms-style time strings with their value in milliseconds.
+
+``` json
+{
+  "maxAge": "1 day"
+}
+```
+
+Will load as:
+
+``` json
+{
+  "maxAge": 86400000
+}
+```
+
 ## license
 
 This software is free to use under the MIT license. See the [LICENSE][] file for license text and copyright information.

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ Config.prototype = {};
  */
 
 Config.prototype.env = require('./lib/env');
+Config.prototype.ms = require('./lib/ms');
 
 /**
  * Load and return the compiled config.

--- a/lib/ms.js
+++ b/lib/ms.js
@@ -1,0 +1,32 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the MIT license. Please see LICENSE file in the project root for terms.
+
+var ms = require('ms');
+
+/**
+ * Plugin to replace ms-style time strings with their value in milliseconds.
+ * @param {String} key
+ * @param {*} val
+ * @returns {*} val
+ */
+
+module.exports = function (key, val) {
+  var valueInMilliseconds;
+
+  // if you give ms a number, it will try to format
+  // it to a string. we only want to convert strings
+  // to numbers, so bail early if val isnt' a string.
+  if (typeof val !== 'string') {
+    return val;
+  }
+
+  // ms will return undefined if it can't convert the
+  // string to a number.
+  valueInMilliseconds = ms(val);
+
+  if (typeof valueInMilliseconds === 'number') {
+    return valueInMilliseconds;
+  }
+
+  return val;
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "deap": "~1.0.0",
     "glob": "~7.0.3",
-    "minimatch": "~3.0.0"
+    "minimatch": "~3.0.0",
+    "ms": "^2.0.0"
   }
 }

--- a/test/plugins.ms.js
+++ b/test/plugins.ms.js
@@ -1,0 +1,32 @@
+var plugin = require('../lib/ms');
+var config = require('..');
+var assert = require('assert');
+
+/* jshint mocha:true */
+/* eslint-env mocha */
+
+describe('plugins/ms', function () {
+
+  it('is available on a config instance', function () {
+    assert.equal(typeof config(__dirname).ms, 'function');
+  });
+
+  it('does nothing for non-string values', function () {
+    assert.deepEqual(JSON.parse('{"foo":23}', plugin), {
+      foo: 23
+    });
+  });
+
+  it('replaces time strings with their millisecond values', function () {
+    assert.deepEqual(JSON.parse('{"foo":"23 hours"}', plugin), {
+      foo: 82800000
+    });
+  });
+
+  it('does nothing if the value is not a time string', function () {
+    assert.deepEqual(JSON.parse('{"foo":"omg"}', plugin), {
+      foo: 'omg'
+    });
+  });
+
+});


### PR DESCRIPTION
Adds a plugin to convert times strings like "1 day" or "24 hours" to their numeric value in milliseconds. Totally inspired by [eson][1] (like most of this project is), but uses [ms][2] under the hood.

[1]: https://github.com/tj/eson
[2]: https://github.com/zeit/ms