### PR TITLE
add plugin support for json5

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,40 @@ Will load as:
 }
 ```
 
+### config.json5
+
+``` js
+// note that you need to load this plugin
+config.use(config.json5.load());
+```
+
+Allows the usage of json5 syntax in your config files. The JSON5 plugin will not obstruct the usage of other flconf plugins.
+
+``` js
+{
+  // comments are totally fine!
+  bool: true,
+  number: 100,
+  string: 'Human Readable JSON',
+  object: {},
+  array: [],
+  null: null
+}
+```
+
+Will load as:
+
+``` js
+{
+  bool: true,
+  number: 100,
+  string: 'Human Readable JSON',
+  object: {},
+  array: [],
+  null: null
+}
+```
+
 ## license
 
 This software is free to use under the MIT license. See the [LICENSE][] file for license text and copyright information.

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ Config.prototype = {};
 
 Config.prototype.env = require('./lib/env');
 Config.prototype.ms = require('./lib/ms');
+Config.prototype.json5 = require('./lib/json5');
 
 /**
  * Load and return the compiled config.

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -1,0 +1,25 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the MIT license. Please see LICENSE file in the project root for terms.
+
+var JSON5 = require('json5');
+
+/**
+ * * Identity resolver
+ * @param {String} key
+ * @param {*} val
+ * @returns {*} val
+ */
+
+var identity = module.exports = function (key, val) {
+	return val;
+};
+
+/**
+ * Module Loader
+ * @returns {Function} identity
+ */
+
+module.exports.load = function () {
+	JSON.parse = JSON5.parse;
+	return identity;
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "deap": "~1.0.0",
     "glob": "~7.0.3",
+    "json5": "^0.5.1",
     "minimatch": "~3.0.0",
     "ms": "^2.0.0"
   }

--- a/test/plugins.json5.integration.js
+++ b/test/plugins.json5.integration.js
@@ -1,0 +1,33 @@
+
+var env = require('../lib/env');
+var ms = require('../lib/ms');
+var json5 = require('../lib/json5');
+var assert = require('assert');
+
+/* jshint mocha:true */
+/* eslint-env mocha */
+
+var resolver = function (key, value) {
+  return [json5, env, ms].reduce(function (val, plugin) {
+    return plugin(key, val);
+  }, value);
+};
+
+describe('plugins/json5 integration', function () {
+
+  before(function () {
+    process.env.FOO = 'FOO';
+    json5.load();
+  });
+
+  it('should not obstruct other flconf plugins', function () {
+    assert.deepStrictEqual(JSON.parse("{foo:23, bar: 'yes', baz: true, week: '7 days', FOO: '${FOO}'}", resolver), {
+      foo: 23,
+      bar: 'yes',
+      baz: true,
+      week: 604800000,
+      FOO: 'FOO'
+    });
+  });
+
+});

--- a/test/plugins.json5.js
+++ b/test/plugins.json5.js
@@ -1,0 +1,48 @@
+var plugin = require('../lib/json5');
+var config = require('..');
+var assert = require('assert');
+
+/* jshint mocha:true */
+/* eslint-env mocha */
+
+describe('plugins/json5', function () {
+
+  before(function () {
+    plugin.load();
+  });
+
+  it('is available on a config instance', function () {
+    assert.equal(config(__dirname).json5, plugin);
+  });
+
+  it('parses regular json', function () {
+    assert.deepStrictEqual(JSON.parse('{"foo":23, "bar": "yes", "baz": true}', plugin), {
+      foo: 23,
+      bar: 'yes',
+      baz: true
+    });
+  });
+
+  it('parses json5', function () {
+    assert.deepStrictEqual(JSON.parse("{foo:23, bar: 'yes', baz: true}", plugin), {
+      foo: 23,
+      bar: 'yes',
+      baz: true
+    });
+  });
+
+  it('should itself be an identity resolver', function () {
+    var resolver = plugin;
+
+    assert.equal(typeof resolver, 'function');
+    assert.equal(resolver('key', 'value'), 'value');
+  });
+
+  it('should return an identity resolver from the load method', function () {
+    var resolver = plugin.load();
+
+    assert.equal(typeof resolver, 'function');
+    assert.equal(resolver('key', 'value'), 'value');
+  });
+
+});


### PR DESCRIPTION
I am leaning toward JSON5 being cool. This is a simple plugin that allows for JSON5 use within flconf-igs.

https://www.npmjs.com/package/json5
https://github.com/json5/json5

One issue to address is the extension naming convention for json5. It does not seem like there is a standard because json5 is not a standard. So for now all config files will still need to have ```.json``` in order for the flconf globbing to locate the config file.