### PR TITLE
Make the parse method and glob pattern public

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,25 @@ Config.prototype.env = require('./lib/env');
 Config.prototype.ms = require('./lib/ms');
 
 /**
+ * Define the method used to parse config files.
+ * You may override this method with another function
+ * that accepts source text and a reviver function
+ * with the same signature as JSON.parse expects.
+ * @param {String} text
+ * @param {Function} reviver
+ * @type {Function}
+ */
+
+Config.prototype.parse = JSON.parse;
+
+/**
+ * Define the glob pattern used for finding config files.
+ * @type {String}
+ */
+
+Config.prototype.pattern = '**/*.json';
+
+/**
  * Load and return the compiled config.
  * @returns {Object}
  */
@@ -66,7 +85,7 @@ Config.prototype.use = function (foo) {
 
 Config.prototype.files = function () {
   var array = [];
-  var files = glob.sync('**/*.json', {
+  var files = glob.sync(this.pattern, {
     cwd: this.dirname
   });
 
@@ -99,7 +118,7 @@ Config.prototype.process = function (files) {
 
   for (i = 0; i < files.length; i++) {
     source = fs.readFileSync(path.join(this.dirname, files[i]), 'utf8');
-    config = JSON.parse(source, this.reviver());
+    config = this.parse(source, this.reviver());
 
     extend(obj, config);
   }

--- a/test/main.js
+++ b/test/main.js
@@ -10,8 +10,28 @@ describe('main', function () {
     assert.throws(config, /Config directory is required/);
   });
 
-  it('returns an object', function () {
-    assert.deepEqual(config(__dirname).load(), {});
+  describe('#load', function () {
+
+    it('returns an object', function () {
+      assert.deepEqual(config(__dirname).load(), {});
+    });
+
+  });
+
+  describe('#parse', function () {
+
+    it('defaults to JSON.parse', function () {
+      assert.strictEqual(config(__dirname).parse, JSON.parse);
+    });
+
+  });
+
+  describe('#pattern', function () {
+
+    it('defaults to a glob for .json files', function () {
+      assert.equal(config(__dirname).pattern, '**/*.json');
+    });
+
   });
 
 });


### PR DESCRIPTION
This allows users to override the config format, for example with either JSON5 or YAML

``` js
var config = require('flconf')(__dirname);
var JSON5 = require('json5');

// use json5 for configs
config.parse = JSON5.parse;
config.pattern = '**/*.json5';
```